### PR TITLE
Cron core: handle empty "AND" values

### DIFF
--- a/libs/cron-core/package.json
+++ b/libs/cron-core/package.json
@@ -1,4 +1,4 @@
 {
 	"name": "@sbzen/cron-core",
-	"version": "0.0.2"
+	"version": "0.0.3"
 }

--- a/libs/cron-core/src/lib/mode.enum.ts
+++ b/libs/cron-core/src/lib/mode.enum.ts
@@ -76,7 +76,7 @@ export class ModeUtils {
 			return str.split(Separator.INCREMENT);
 		}
 		if (Mode.AND === mode) {
-			return str.split(Separator.AND);
+			return str.split(Separator.AND).filter(value => !!value);
 		}
 		if (Mode.RANGE === mode) {
 			return str.split(Separator.RANGE);


### PR DESCRIPTION
Issue with generating invalid cron value in case of empty "AND" values array.