### PR TITLE
re-cron: handle empty "AND" values

### DIFF
--- a/libs/re-cron/package.json
+++ b/libs/re-cron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sbzen/re-cron",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Quartz Cron Component - React",
   "author": "Serhii Bzenko <bzenkosergey@gmail.com>",
   "license": "MIT",
@@ -22,7 +22,7 @@
 	"quartz cron"
   ],
   "dependencies": {
-	"@sbzen/cron-core": "0.0.2"
+	"@sbzen/cron-core": "0.0.3"
   },
   "peerDependencies": {
     "react": "*",

--- a/libs/re-cron/src/lib/tabs/tab-base.abstract.ts
+++ b/libs/re-cron/src/lib/tabs/tab-base.abstract.ts
@@ -75,14 +75,18 @@ export abstract class TabBaseComponent<P extends TabBaseProps, S extends TabBase
 	protected toggleSpecifics(value: string, mode: Mode, segment: Segments) {
 		const view = this.getView(segment);
 		const values = view.values[mode].values;
-
-		if (!~values.indexOf(value)) {
-			values.push(value);
-		} else {
-			const i = values.indexOf(value);
-			values.splice(i, 1);
+		const isRemoving = !!~values.indexOf(value);
+		if (isRemoving && values.length === 1) {
+			this.applyChanges();
+			return;
 		}
 
+		if (isRemoving) {
+			const i = values.indexOf(value);
+			values.splice(i, 1);
+		} else {
+			values.push(value);
+		}
 		this.setView(segment, view);
 		this.applyChanges();
 	}


### PR DESCRIPTION
Issue with generating invalid cron value in case of empty "AND" values array.