### PR TITLE
ng-cron: handle empty "AND" values

### DIFF
--- a/libs/ng-cron/package.json
+++ b/libs/ng-cron/package.json
@@ -25,7 +25,7 @@
 	"quartz cron"
   ],
   "dependencies": {
-	"@sbzen/cron-core": "0.0.2"
+	"@sbzen/cron-core": "0.0.3"
   },
   "peerDependencies": {
     "@angular/common": "^8.2.4",

--- a/libs/ng-cron/src/lib/cron.component.ts
+++ b/libs/ng-cron/src/lib/cron.component.ts
@@ -1,4 +1,4 @@
-import { Component, forwardRef, Input, ChangeDetectionStrategy, Output, EventEmitter, ViewChildren, ElementRef, QueryList } from '@angular/core';
+import { Component, forwardRef, Input, ChangeDetectionStrategy, ChangeDetectorRef, Output, EventEmitter, ViewChildren, ElementRef, QueryList } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { Type, Segment, CoreService } from '@sbzen/cron-core';
@@ -42,7 +42,10 @@ export class QuartzCronComponent implements ControlValueAccessor {
 	tabs = tabs;
 	tab = this.tabs[0];
 
-	constructor(private quartzCron: QuartzCronService) {}
+	constructor(
+		private quartzCron: QuartzCronService,
+		private cd: ChangeDetectorRef
+	) {}
 
 	navigateTab(code: string, type: Type) {
 		if (code !== 'ArrowRight' && code !== 'ArrowLeft') {
@@ -63,6 +66,7 @@ export class QuartzCronComponent implements ControlValueAccessor {
 
 		this.tab = this.tabs[toPos];
 		tabEls[toPos].focus();
+		this.cd.detectChanges();
 	}
 
 	getView(segment: Segment) {
@@ -71,6 +75,7 @@ export class QuartzCronComponent implements ControlValueAccessor {
 
 	writeValue(cronValue: string) {
 		this.quartzCron.fillFromExpression(cronValue);
+		this.cd.detectChanges();
 	}
 
 	registerOnChange(fn: (cronValue: string) => {}) {

--- a/libs/ng-cron/src/lib/tabs/day/day.component.ts
+++ b/libs/ng-cron/src/lib/tabs/day/day.component.ts
@@ -87,9 +87,20 @@ export class DayComponent extends TabBaseComponent {
 		return this.quartzCron.hasValue(value, segment, mode);
 	}
 
+	handleSpecificsChange(e: Event, value: string, mode: Mode, segment: TabSegments) {
+		const values = this.quartzCron.getValues(segment, mode);
+		const isRemoving = !!~values.indexOf(value);
+		if (isRemoving && values.length === 1) {
+			e.preventDefault();
+			return;
+		}
+	}
+
 	toggleSpecifics(value: string, mode: Mode, segment: TabSegments) {
 		const values = this.quartzCron.getValues(segment, mode);
-		if (!~values.indexOf(value)) {
+		const isRemoving = !!~values.indexOf(value);
+	
+		if (!isRemoving) {
 			values.push(value);
 			this.applyChanges();
 			return;

--- a/libs/ng-cron/src/lib/tabs/day/day.html
+++ b/libs/ng-cron/src/lib/tabs/day/day.html
@@ -161,6 +161,7 @@
 					[value]="item.value"
 					[disabled]="isDisabled(segment.dayOfWeek, mode.AND)"
 					[checked]="inSpecificsList(item.value, mode.AND, segment.dayOfWeek)"
+					(click)="handleSpecificsChange($event, item.value, mode.AND, segment.dayOfWeek)"
 					(change)="toggleSpecifics(item.value, mode.AND, segment.dayOfWeek)">
 
 				<label
@@ -206,6 +207,7 @@
 					[value]="item.value"
 					[disabled]="isDisabled(segment.dayOfMonth, mode.AND)"
 					[checked]="inSpecificsList(item.value, mode.AND, segment.dayOfMonth)"
+					(click)="handleSpecificsChange($event, item.value, mode.AND, segment.dayOfMonth)"
 					(change)="toggleSpecifics(item.value, mode.AND, segment.dayOfMonth)">
 
 				<label

--- a/libs/ng-cron/src/lib/tabs/hour/hour.html
+++ b/libs/ng-cron/src/lib/tabs/hour/hour.html
@@ -100,6 +100,7 @@
 					[value]="item.value"
 					[disabled]="isDisabled(mode.AND)"
 					[checked]="inSpecificsList(item.value, mode.AND)"
+					(click)="handleSpecificsChange($event, item.value, mode.AND)"
 					(change)="toggleSpecifics(item.value, mode.AND)">
 
 				<label

--- a/libs/ng-cron/src/lib/tabs/minute/minute.html
+++ b/libs/ng-cron/src/lib/tabs/minute/minute.html
@@ -100,6 +100,7 @@
 					[value]="item.value"
 					[disabled]="isDisabled(mode.AND)"
 					[checked]="inSpecificsList(item.value, mode.AND)"
+					(click)="handleSpecificsChange($event, item.value, mode.AND)"
 					(change)="toggleSpecifics(item.value, mode.AND)">
 
 				<label

--- a/libs/ng-cron/src/lib/tabs/month/month.html
+++ b/libs/ng-cron/src/lib/tabs/month/month.html
@@ -100,6 +100,7 @@
 					[value]="item.value"
 					[disabled]="isDisabled(mode.AND)"
 					[checked]="inSpecificsList(item.value, mode.AND)"
+					(click)="handleSpecificsChange($event, item.value, mode.AND)"
 					(change)="toggleSpecifics(item.value, mode.AND)">
 
 				<label

--- a/libs/ng-cron/src/lib/tabs/second/second.html
+++ b/libs/ng-cron/src/lib/tabs/second/second.html
@@ -100,6 +100,7 @@
 					[value]="item.value"
 					[disabled]="isDisabled(mode.AND)"
 					[checked]="inSpecificsList(item.value, mode.AND)"
+					(click)="handleSpecificsChange($event, item.value, mode.AND)"
 					(change)="toggleSpecifics(item.value, mode.AND)">
 
 				<label

--- a/libs/ng-cron/src/lib/tabs/tab-single-segment.component.ts
+++ b/libs/ng-cron/src/lib/tabs/tab-single-segment.component.ts
@@ -25,15 +25,15 @@ export abstract class TabSingleSegmentComponent extends TabBaseComponent {
 
 	setSelected(mode: Mode) {
 		this.view.selected = mode;
-		this.cd.detectChanges();
-		this.cd.detach();
 		this.applyChanges();
+		this.cd.detectChanges();
 	}
 
 	setInValue(mode: Mode, index: 0|1, value: string) {
 		const source = this.getModelValues(mode);
 		source[index] = value;
 		this.applyChanges();
+		this.cd.detectChanges();
 	}
 
 	getModelValues(mode: Mode) {
@@ -44,17 +44,30 @@ export abstract class TabSingleSegmentComponent extends TabBaseComponent {
 		return this.quartzCron.hasValue(value, this.segment, mode);
 	}
 
+	handleSpecificsChange(e: Event, value: string, mode: Mode) {
+		const values = this.quartzCron.getValues(this.segment, mode);
+		const isRemoving = !!~values.indexOf(value);
+		if (isRemoving && values.length === 1) {
+			e.preventDefault();
+			return;
+		}
+	}
+
 	toggleSpecifics(value: string, mode: Mode) {
 		const values = this.quartzCron.getValues(this.segment, mode);
-		if (!~values.indexOf(value)) {
+		const isRemoving = !!~values.indexOf(value);
+
+		if (!isRemoving) {
 			values.push(value);
 			this.applyChanges();
+			this.cd.detectChanges();
 			return;
 		}
 
 		const i = values.indexOf(value);
 		values.splice(i, 1);
 		this.applyChanges();
+		this.cd.detectChanges();
 	}
 
 	isDisabled(mode?: Mode) {

--- a/libs/ng-cron/src/lib/tabs/year/year.html
+++ b/libs/ng-cron/src/lib/tabs/year/year.html
@@ -100,6 +100,7 @@
 					[value]="item.value"
 					[disabled]="isDisabled(mode.AND)"
 					[checked]="inSpecificsList(item.value, mode.AND)"
+					(click)="handleSpecificsChange($event, item.value, mode.AND)"
 					(change)="toggleSpecifics(item.value, mode.AND)">
 
 				<label


### PR DESCRIPTION
Issue with generating invalid cron value in case of empty "AND" values array.